### PR TITLE
Add TypeScript definition to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lib/create-date.js",
     "lib/create-datetime-float.js",
     "lib/create-time.js",
-    "lib/format-num.js"
+    "lib/format-num.js",
+    "index.d.ts"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
`index.d.ts` was recently added to the repo but it has not been published to npm yet.