### PR TITLE
chore(changelog,test): @ltd/j-toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@
 ## Fixes
 
 * Fix bug where keys with names matching javascript Object methods would
-  error.  Thanks @LongTengDao for finding this!
+  error.  Thanks [@LongTengDao](https://github.com/LongTengDao) for finding this!
 * Fix bug where a bundled version would fail if `util.inspect` wasn't
   provided.  This was supposed to be guarded against, but there was a bug in
-  the guard. Thanks @agriffis for finding and fixing this!
+  the guard. Thanks [@agriffis](https://github.com/agriffis) for finding and fixing this!
 
 ## Misc
 
@@ -37,7 +37,7 @@ Node 6 and 8 are measurably slower than Node 6, 10 and 11, at least when it come
 ## Features
 
 * Typescript: Lots of improvements to our type definitions, many many to
-  @jorgegonzalez and @momocow for working through these.
+  [@jorgegonzalez](https://github.com/jorgegonzalez) and [@momocow](https://github.com/momocow) for working through these.
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-* Support parsing and stringifying objects with `__proto` properties. ([@LongTengDao](https://github.com/LongTengDao))
+* Support parsing and stringifying objects with `__proto__` properties. ([@LongTengDao](https://github.com/LongTengDao))
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ $ npm run benchmark
 
 The results below are from my laptop using Node 10.6.0.  The library
 versions tested were `@iarna/toml@2.2.2`, `toml-j0.4@1.1.1`, `toml@3.0.0`,
-`@sgarciac/bombadil@2.1.0` and `@ltd/j-toml@0.5.45`.  The speed value is
+`@sgarciac/bombadil@2.1.0` and `@ltd/j-toml@0.5.46`.  The speed value is
 megabytes-per-second that the parser can process of that document type.
 Bigger is better.  The second number is the margin of error, lower implies
 more consistent performance.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ $ npm run benchmark
 
 The results below are from my laptop using Node 10.6.0.  The library
 versions tested were `@iarna/toml@2.2.2`, `toml-j0.4@1.1.1`, `toml@3.0.0`,
-`@sgarciac/bombadil@2.1.0` and `@ltd/j-toml@0.5.46`.  The speed value is
+`@sgarciac/bombadil@2.1.0` and `@ltd/j-toml@0.5.45`.  The speed value is
 megabytes-per-second that the parser can process of that document type.
 Bigger is better.  The second number is the margin of error, lower implies
 more consistent performance.

--- a/benchmark-per-file.js
+++ b/benchmark-per-file.js
@@ -42,7 +42,7 @@ function parseBombadil (str) {
 }
 const ltdToml = require('@ltd/j-toml')
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n')
+  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER)
 }
 
 let results

--- a/benchmark.js
+++ b/benchmark.js
@@ -41,7 +41,7 @@ function parseBombadil (str) {
 }
 const ltdToml = require('@ltd/j-toml')
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n')
+  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER)
 }
 const fixtures = glob(`${__dirname}/benchmark/*.toml`)
   .concat(glob(`${__dirname}/test/spec-test/*toml`))

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "description": "Better TOML parsing and stringifying all in that familiar JSON interface.",
   "dependencies": {},
   "devDependencies": {
-    "@ltd/j-toml": "^0.5.45",
+    "@ltd/j-toml": "^0.5.46",
     "@perl/qx": "^1.0.2",
     "@sgarciac/bombadil": "^2.1.0",
     "ansi": "^0.3.1",

--- a/spec-compliance/burntsushi-toml-test.js
+++ b/spec-compliance/burntsushi-toml-test.js
@@ -43,7 +43,7 @@ const toTest = [
     }
   },
   {
-    name: '@ltd/j-toml@0.5.46',
+    name: '@ltd/j-toml@'+ltdToml.version,
     parse: parseLtdToml
   }
 ]

--- a/spec-compliance/burntsushi-toml-test.js
+++ b/spec-compliance/burntsushi-toml-test.js
@@ -10,7 +10,7 @@ const parseTomlj04 = require('toml-j0.4').parse
 const bombadil = require('@sgarciac/bombadil')
 const ltdToml = require('@ltd/j-toml')
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n')
+  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER)
 }
 
 class BombadilError extends Error {}

--- a/spec-compliance/burntsushi-toml-test.js
+++ b/spec-compliance/burntsushi-toml-test.js
@@ -43,7 +43,7 @@ const toTest = [
     }
   },
   {
-    name: '@ltd/j-toml@0.5.45',
+    name: '@ltd/j-toml@0.5.46',
     parse: parseLtdToml
   }
 ]

--- a/spec-compliance/local-spec-test.js
+++ b/spec-compliance/local-spec-test.js
@@ -39,7 +39,7 @@ const toTest = [
     }
   },
   {
-    name: '@ltd/j-toml@0.5.46',
+    name: '@ltd/j-toml@'+ltdToml.version,
     parse: parseLtdToml
   }
 ]

--- a/spec-compliance/local-spec-test.js
+++ b/spec-compliance/local-spec-test.js
@@ -8,7 +8,7 @@ const parseTomlj04 = require('toml-j0.4').parse
 const bombadil = require('@sgarciac/bombadil')
 const ltdToml = require('@ltd/j-toml')
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n')
+  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER)
 }
 
 class BombadilError extends Error {}

--- a/spec-compliance/local-spec-test.js
+++ b/spec-compliance/local-spec-test.js
@@ -39,7 +39,7 @@ const toTest = [
     }
   },
   {
-    name: '@ltd/j-toml@0.5.45',
+    name: '@ltd/j-toml@0.5.46',
     parse: parseLtdToml
   }
 ]


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

> <https://github.com/iarna/iarna-toml/issues/12#issuecomment-464887740>

1. [x] I found most parsing test errors are because `@ltd/j-toml` used `BigInt` to eval `Interger` by default, while the tester using `number` and `BigInt` which depends. So all test like table test or array test which including`Integer` failed. The 4th parameter of `parse` could resolve that.

2. [x] Rest parsing errors are because the implementation of `Datetime` are different for each parser. I think the implementation of `@iarna/toml` is good, so I improved my parser in `0.5.46`. And I updated the version in the test; `@ltd/j-toml` has a property `version`, ao I replaced the hardcoded version by that.

3. [ ] I didn't run the test-compare program for generating new result, but just change the config above, that would help the PR change minimal, and the result by your self is more bilievable. But that means it will trouble you to run it again, so much thanks.

4. [x] Other fix. Like `__proto__`, and the `@username` (which linked somewhere, and non-linked somewhere, I think maybe it's not a feature, but a bug? \:).
