### PR TITLE
Update burntsushi-toml-test.js

### DIFF
--- a/spec-compliance/burntsushi-toml-test.js
+++ b/spec-compliance/burntsushi-toml-test.js
@@ -15,7 +15,7 @@ const bombadilVersion = require('@sgarciac/bombadil/package.json').version
 const ltdToml = require('@ltd/j-toml')
 const ltdTomlVersion = require('@ltd/j-toml/package.json').version
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER)
+  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER, {open: true})
 }
 
 class BombadilError extends Error {

--- a/spec-compliance/burntsushi-toml-test.js
+++ b/spec-compliance/burntsushi-toml-test.js
@@ -15,7 +15,7 @@ const bombadilVersion = require('@sgarciac/bombadil/package.json').version
 const ltdToml = require('@ltd/j-toml')
 const ltdTomlVersion = require('@ltd/j-toml/package.json').version
 function parseLtdToml (str) {
-  return ltdToml.parse(str, 0.5, '\n', Number.MAX_SAFE_INTEGER, {open: true})
+  return ltdToml.parse(str, 0.4, '\n', Number.MAX_SAFE_INTEGER)
 }
 
 class BombadilError extends Error {


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

I added an option for the parsing case below (which is valid in 0.4 spec test) in the latest version of [\@ltd/j-toml](https://www.npmjs.com/package/@ltd/j-toml). Thank you!

```toml
[a.b]
[a]
```