### PR TITLE
docs: Fixes CHANGELOG.md format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ changes as a consumer of TOML are actually pretty impactful:
 * Control chars are no longer allowed in comments. Only tabs may be used in comments.
 * Multiline basic and literal strings can have quotes nestled up next to the closing triplet, that is:
   `""""Hello," she said, "this is a thing.""""` is the equivalent of the JSON `"\"Hello,\" she said, \"this is a thing.\""`.
-* Subtables may not extend tables created via dotted keys, that is, the following is invalid:```
+* Subtables may not extend tables created via dotted keys, that is, the following is invalid:
+```
 [a]
 x.y = 1
 [a.x]


### PR DESCRIPTION
The CHANGELOG.md file is not being properly rendered
A missing new line was breaking the formatting

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
