### PR TITLE
Add ESM Support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@iarna/toml",
   "version": "3.0.0",
+  "type": "commonjs",
   "main": "./toml.js",
   "exports": {
     ".": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@iarna/toml",
   "version": "3.0.0",
-  "main": "toml.js",
+  "main": "./toml.js",
+  "exports": {
+    ".": [
+      {
+        "require": "./toml.js",
+        "import": "./toml-esm.mjs"
+      },
+      "./toml.js"
+    ],
+    "./esm": "./toml-esm.mjs"
+  },
   "scripts": {
     "test": "tap -J --100 test/*.js test/toml-stream/*.js",
     "benchmark": "node benchmark.js && node benchmark-per-file.js && node results2table.js",

--- a/toml-esm.mjs
+++ b/toml-esm.mjs
@@ -1,2 +1,2 @@
-export {default as parse} from './parse.js';
-export {default as stringify} from './stringify.js';
+export {default as parse} from './parse.js'
+export {default as stringify} from './stringify.js'

--- a/toml-esm.mjs
+++ b/toml-esm.mjs
@@ -1,0 +1,2 @@
+export {default as parse} from './parse.js';
+export {default as stringify} from './stringify.js';


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
This PR adds full ESM support for all viable versions (Node 12-14 and above), while also maintaining full CommonJS support in every version. This is achieved through a very simple wrapper file that re-exports CommonJS code as ESM, but only when an `import` statement is used instead of `require()`.

Node 12-13 have highly experimental ESM support that may require a flag and/or a subpath (`import "@iarna/toml/esm"`) in order to function. If you don't wish to support this, or if you find the `/esm` subpath messy, you could easily remove the `"./esm": "./toml-esm.mjs"` line from the `package.json` file, while still maintaining full ESM support in Node 14 and all later versions.

I was unsure if any documentation is necessary for this change, but I would think at most a small note would be enough. Feel free to let me know if (and ideally what kind of) documentation is necessary.

Fixes #32 