### PR TITLE
Make parse() to accept generic types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,17 +19,17 @@ interface FuncParse {
   /**
    * Synchronously parse a TOML string and return an object.
    */
-  (toml: string): JsonMap
+  <Parsed = JsonMap>(toml: string): Parsed
 
   /**
    * Asynchronously parse a TOML string and return a promise of the resulting object.
    */
-  async (toml: string, options?: ParseOptions): Promise<JsonMap>
+  async <Parsed = JsonMap>(toml: string, options?: ParseOptions): Promise<Parsed>
 
   /**
    * Given a readable stream, parse it as it feeds us data. Return a promise of the resulting object.
    */
-  stream (readable: NodeJS.ReadableStream): Promise<JsonMap>
+  stream <Parsed = JsonMap>(readable: NodeJS.ReadableStream): Promise<Parsed>
   stream (): Transform
 }
 


### PR DESCRIPTION
Hello. 🐱 

Currently `parse()` returns the `JsonMap` type.
So we need to use type casting to apply our own types like this.

```ts
const myConfig = parse(input) as unknown as MyConfig;
```

This PR make `parse()` to accept generic types like this.

```ts
const myConfig = parse<MyConfig>(input);
```

See also this [TS playground](https://www.typescriptlang.org/play?strict=true&ssl=41&ssc=45&pln=41&pc=1#code/PTAEDECcHsFtQMYFdKQKYDsAuosE8AHNUAEzQDMBnAWACh8jQApS6DANQEMAbJYgXlAAjaNG5pOGUAB9QGJLCFpIM0JSyQAlhgDmqlmwCynAvtYYAgqk55VAEU5Y0dBsQOXrtwe6680AbQBdF0JiCww8d1BBETEJKVl5RWVVdS1dMyMTe0diWXcrSBtMjyK8ILo6bSdIck4EN3NjUwBvOlBQfwBrNDwALjUNbR1AgfDI8wBuOgBfStoQUAB5LR1tHlxCYZpaauU6hogkDAQABU5ISjQARlA22g6ACiw4bgG04YBKAfdm9tBFgA6YGzOgINjqUAEC5Xa4DcDHM4wm7RUDPV6faIAPmYAGUlgA5QHQy5odGwbifaa0OiLAC0DMZTOZLNZbPZHLp81coEMeAAwmxyJo9IJ7h1OAMkkpINSOkIAPzvIa6akzalgiE4bQEJA4QQAIk4qOuBo1CzAAFEAErWgb8yQAchwnEolBFUhImnQCCw3DwmowkNgAqFIuuAH04bzQxhhaKocjro8dXqqbSwAS0GgSLhoJtGAhXVhgYDA8HY-HIwAmVEk2EpjC6rCY12gY5dDDQADuUjbfMFcZF5vpnLH44nzPmi1OMAI0CuuYY2yq2H29WICJO51JtfFoAAPDvF6jfiYseS3oN0jpvqBjzn-kCQbQ5rRwUGcPW0NX4YiH7WgiXpi-A4kw+JEt+wEjpmPagJoODdtAkBdJQoDdghAAW0B6gWxBFuoACE5Y4CGg7xtWUZ1si1YHgOYY6BeqYttSiwAJLkHI0A4JQRAIJowo5gANLgmHEJQnCwMQGFYJhiAoOg2DCGgmGcAAbpoyGPN4TQmJ8JGgGRDGUYBia7o2zbprQQA).