### PR TITLE
chore: remove eval to allow execution without unsafe-eval CSP

### DIFF
--- a/lib/toml-parser.js
+++ b/lib/toml-parser.js
@@ -172,16 +172,7 @@ function isList (obj) {
   return obj[_type] === LIST
 }
 
-// in an eval, to let bundlers not slurp in a util proxy
-let _custom
-try {
-  const utilInspect = eval("require('util').inspect")
-  _custom = utilInspect.custom
-} catch (_) {
-  /* eval require not available in transpiled bundle */
-}
-/* istanbul ignore next */
-const _inspect = _custom || 'inspect'
+const _inspect = 'inspect'
 
 class BoxedBigInt {
   constructor (value) {


### PR DESCRIPTION
## Motivation

Closes #45 

## Approach

Remove code that uses eval to `require('util').inspect`. This might be the wrong solution but we can use this as a starting point to figure out what the right solution should be.