### PR TITLE
Fix BigInt support

### DIFF
--- a/lib/toml-parser.js
+++ b/lib/toml-parser.js
@@ -183,10 +183,12 @@ try {
 /* istanbul ignore next */
 const _inspect = _custom || 'inspect'
 
+const hasBigInt = typeof(BigInt) === 'function'
+
 class BoxedBigInt {
   constructor (value) {
     try {
-      this.value = global.BigInt.asIntN(64, value)
+      this.value = BigInt.asIntN(64, value)
     } catch (_) {
       /* istanbul ignore next */
       this.value = null
@@ -215,7 +217,7 @@ function Integer (value) {
   // -0 is a float thing, not an int thing
   if (Object.is(num, -0)) num = 0
   /* istanbul ignore else */
-  if (global.BigInt && !Number.isSafeInteger(num)) {
+  if (hasBigInt) {
     return new BoxedBigInt(value)
   } else {
     /* istanbul ignore next */


### PR DESCRIPTION
global.BigInt is never defined for me (Node v18.16), so it's never used.

Use typeof(BigInt) === 'function' instead; that's what e.g. this polyfill uses: https://github.com/peterolson/BigInteger.js/blob/master/BigInteger.js

Also always use BigInt, which seems easier to me, and applications can easily tell if something was given as an int or float.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
