### PR TITLE
fix: support CRLF line endings in comments

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -57,6 +57,9 @@ class Parser {
     ++this.col
     return this.haveBuffer()
   }
+  peekChar () {
+    return this._buf.codePointAt(this.ii + 1)
+  }
   haveBuffer () {
     return this.ii < this._buf.length
   }

--- a/lib/toml-parser.js
+++ b/lib/toml-parser.js
@@ -386,6 +386,8 @@ function makeParserClass (Parser) {
       do {
         if (this.char === Parser.END || this.char === CTRL_J) {
           return this.return()
+        } else if (this.char === CTRL_M && this.peekChar() === CTRL_J) {
+          // CRLF line ending, LF is consumed on next iter
         } else if (this.char === CHAR_DEL || (this.char <= CTRL_CHAR_BOUNDARY && this.char !== CTRL_I)) {
           throw this.errorControlCharIn('comments')
         }


### PR DESCRIPTION
The TOML v1.0.0 spec explicitly states that newlines are marked by either LF or CRLF sequences, and that comments are to be ended by newlines. Thus, it follows that the control characters used for newline sequences are in accordance to the specification.

These changes introduce support for CRLF line endings in comments by peeking if a CR is followed by a LF during comment parsing. If that's the case, no unexpected control character error is thrown. I've tested these changes to work fine with both LF and CRLF files. I also tested spec conformance by introducing a stray CR in the middle of a comment line, which still causes a control character error to be thrown, as expected.

Fixes: #33 